### PR TITLE
Fix global npm installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.4] - 2025-08-11
+
+### Fixed
+
+- Fixed npm global package permission issues by installing packages to user-specific directory (/home/vscode/.npm-global)
+- Fixed build errors related to missing /home/vscode directory and .npm cache directory
+- Global npm packages can now be upgraded without permission errors in devcontainer environments
+
 ## [0.0.3] - 2025-06-26
 
 ### Added

--- a/noble-full/setup.sh
+++ b/noble-full/setup.sh
@@ -20,6 +20,9 @@ curl -s https://raw.githubusercontent.com/jvrck/pyinfo/master/install | sudo bas
 # Anything that requires npm or nodejs should be done here.
 source /usr/local/share/nvm/nvm.sh
 
+# Create vscode user home directory if it doesn't exist
+mkdir -p /home/vscode
+
 # Fix npm global package permissions for the vscode user (UID 1000)
 # This allows the user to upgrade global packages without permission issues
 npm config set prefix /home/vscode/.npm-global
@@ -27,6 +30,7 @@ mkdir -p /home/vscode/.npm-global
 chown -R 1000:1000 /home/vscode/.npm-global
 
 # Add npm global bin to PATH for vscode user
+touch /home/vscode/.bashrc /home/vscode/.zshrc
 echo 'export PATH=/home/vscode/.npm-global/bin:$PATH' >> /home/vscode/.bashrc
 echo 'export PATH=/home/vscode/.npm-global/bin:$PATH' >> /home/vscode/.zshrc
 
@@ -42,5 +46,8 @@ npm install -g repomix
 # CCUage
 npm install -g ccusage
 
-# Ensure vscode user owns the npm cache
+# Create and ensure vscode user owns the npm cache (if it exists)
+mkdir -p /home/vscode/.npm
 chown -R 1000:1000 /home/vscode/.npm
+# Also ensure vscode owns their home directory
+chown -R 1000:1000 /home/vscode

--- a/noble-full/setup.sh
+++ b/noble-full/setup.sh
@@ -19,6 +19,19 @@ curl -s https://raw.githubusercontent.com/jvrck/pyinfo/master/install | sudo bas
 
 # Anything that requires npm or nodejs should be done here.
 source /usr/local/share/nvm/nvm.sh
+
+# Fix npm global package permissions for the vscode user (UID 1000)
+# This allows the user to upgrade global packages without permission issues
+npm config set prefix /home/vscode/.npm-global
+mkdir -p /home/vscode/.npm-global
+chown -R 1000:1000 /home/vscode/.npm-global
+
+# Add npm global bin to PATH for vscode user
+echo 'export PATH=/home/vscode/.npm-global/bin:$PATH' >> /home/vscode/.bashrc
+echo 'export PATH=/home/vscode/.npm-global/bin:$PATH' >> /home/vscode/.zshrc
+
+# Install global npm packages
+export PATH=/home/vscode/.npm-global/bin:$PATH
 npm install -g @devcontainers/cli
 # install claude-code
 npm install -g @anthropic-ai/claude-code
@@ -28,3 +41,6 @@ npm install -g @google/gemini-cli
 npm install -g repomix
 # CCUage
 npm install -g ccusage
+
+# Ensure vscode user owns the npm cache
+chown -R 1000:1000 /home/vscode/.npm


### PR DESCRIPTION
- Fixed npm global package permission issues by installing packages to user-specific directory (/home/vscode/.npm-global)
- Fixed build errors related to missing /home/vscode directory and .npm cache directory
- Global npm packages can now be upgraded without permission errors in devcontainer environments
