### PR TITLE
ci: stop .dockerbuild artifact uploads (storage cleanup)

### DIFF
--- a/.github/workflows/build-noble.yaml
+++ b/.github/workflows/build-noble.yaml
@@ -1,4 +1,6 @@
 name: Build and Push Noble Full
+env:
+  DOCKER_BUILD_RECORD_UPLOAD: "false"
 
 on:
   push:


### PR DESCRIPTION
Adds DOCKER_BUILD_RECORD_UPLOAD=false so buildx stops auto-uploading per-build .dockerbuild artifacts (they accumulated + ate Actions storage). Image build/push unaffected.